### PR TITLE
fix: add release function to check migration status

### DIFF
--- a/lib/admin/release.ex
+++ b/lib/admin/release.ex
@@ -6,17 +6,60 @@ defmodule Admin.Release do
   @app :admin
   require Logger
 
-  def migrate do
+  @doc """
+  Migrate the database. Defaults to migrating to the latest, `[all: true]`
+  Also accepts `[step: 1]` or `[to: 20200118045751]`
+  """
+  def migrate(opts \\ [all: true]) do
     load_app()
 
     for repo <- repos() do
-      {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
+      {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, opts))
     end
   end
 
   def rollback(repo, version) do
     load_app()
     {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))
+  end
+
+  @doc """
+  Print the migration status for configured Repos' migrations.
+  """
+  def migration_status do
+    load_app()
+
+    for repo <- repos(), do: print_migrations_for(repo)
+  end
+
+  defp print_migrations_for(repo) do
+    paths = repo_migrations_path(repo)
+
+    {:ok, repo_status, _} =
+      Ecto.Migrator.with_repo(repo, &Ecto.Migrator.migrations(&1, paths), mode: :temporary)
+
+    IO.puts(
+      """
+      Repo: #{inspect(repo)}
+        Status    Migration ID    Migration Name
+      --------------------------------------------------
+      """ <>
+        Enum.map_join(repo_status, "\n", fn {status, number, description} ->
+          "  #{pad(status, 10)}#{pad(number, 16)}#{description}"
+        end) <> "\n"
+    )
+  end
+
+  defp repo_migrations_path(repo) do
+    config = repo.config()
+    priv = config[:priv] || "priv/#{repo |> Module.split() |> List.last() |> Macro.underscore()}"
+    config |> Keyword.fetch!(:otp_app) |> Application.app_dir() |> Path.join(priv)
+  end
+
+  defp pad(content, pad) do
+    content
+    |> to_string
+    |> String.pad_trailing(pad)
   end
 
   defp repos do


### PR DESCRIPTION
In this PR I add a way to check the migration status from the release files.

To use it simply open a iex shell inside the running task (in ECS for example with `mise run remote`)
Inside the shell call the Admin.Release module:

```sh
iex> Admin.Release.migration_status()
```

This will return the migrations that have run and the ones that did not.