### PR TITLE
fix: use more appropriate input type for maintenance form

### DIFF
--- a/lib/admin_web/controllers/planned_maintenance_html/planned_maintenance_form.html.heex
+++ b/lib/admin_web/controllers/planned_maintenance_html/planned_maintenance_form.html.heex
@@ -1,15 +1,14 @@
 <.form :let={f} for={@changeset} action={@action}>
   <.input autofocus field={f[:slug]} type="text" label="Slug" />
-
   <.input
     field={f[:start_at]}
-    type="text"
+    type="datetime-local"
     label="Starts at (UTC, ISO8601)"
     placeholder="2025-10-14T13:30:00Z"
   />
   <.input
     field={f[:end_at]}
-    type="text"
+    type="datetime-local"
     label="Ends at (UTC, ISO8601)"
     placeholder="2025-10-14T13:30:00Z"
   />


### PR DESCRIPTION
Use more appropriate input type for maintenance date form

Below is a video if it in action. there is also a little calendar that can be used.

https://github.com/user-attachments/assets/39565ff2-7645-4f19-955f-6f55dcd6558f

