### PR TITLE
fix: set aws s3 region from env in runtime config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -94,14 +94,6 @@ config :logger, :default_formatter,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
-# Configure AWS with ExAWS with default parameters
-aws_region = System.get_env("AWS_REGION", "eu-central-1")
-
-config :ex_aws, :s3,
-  region: aws_region,
-  # If using custom endpoints like LocalStack or MinIO, path_style: true is often necessary.
-  path_style: true
-
 # Open telemetry configuration
 config :opentelemetry, span_processor: {Sentry.OpenTelemetry.SpanProcessor, []}
 config :opentelemetry, sampler: {Sentry.OpenTelemetry.Sampler, []}

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -151,4 +151,9 @@ if config_env() == :prod do
 
   # Config the File Items bucket name
   config :admin, :file_items_bucket, System.get_env("FILE_ITEMS_BUCKET_NAME", "file-items")
+
+  config :ex_aws, :s3,
+    region: System.get_env("AWS_REGION", "eu-central-1"),
+    # If using custom endpoints like LocalStack or MinIO, path_style: true is often necessary.
+    path_style: true
 end


### PR DESCRIPTION
- fix #76 

### Explanations 

The `config/config.exs` as well as `config/dev.exs`, `config/test.exs`, `config/prod.exs` are compile-time configs. If we read env vars in there, the value will be baked in and will not be able to be changed at runtime.

Instead if we read configs from env vars, use `config/runtime.exs` which is able to read env vars at runtime.

As a quick fix when your app is deployed, you can remote into the task and run:

```iex
> Application.put_env(:ex_aws, :s3, region: "eu-central-2", path_style: true)
:ok
```

This will set the config for the running app. (will not be persisted on restart however).

