### PR TITLE
fix: send emails using Ex_AWS credentials

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -105,7 +105,7 @@ if config_env() == :prod do
   # In production you need to configure the mailer to use a different adapter.
   # Here is an example configuration for Mailgun:
   #
-  config :admin, Admin.Mailer, adapter: Swoosh.Adapters.ExAWSAmazonSES
+  config :admin, Admin.Mailer, adapter: Swoosh.Adapters.ExAwsAmazonSES
 
   #
   # Most non-SMTP adapters require an API client. Swoosh supports Req, Hackney,
@@ -152,6 +152,7 @@ if config_env() == :prod do
     region: System.get_env("AWS_REGION", "eu-central-1"),
     # If using custom endpoints like LocalStack or MinIO, path_style: true is often necessary.
     path_style: true
+
   # Configure Ex_AWS using first env vars, then instance role (automatic credentials in ECS tasks)
   config :ex_aws,
     access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, :pod_identity, :instance_role],


### PR DESCRIPTION
We change the swoosh email adapter to use the ExAwsAmazonSES one because it gets the credentials from the taskRole directly.

ref https://github.com/graasp/graasp-infrastructure/pull/102