### PR TITLE
fix: restrict the deployment concurrency to each env

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,7 +25,7 @@ jobs:
     environment: ${{ inputs.environment || 'development' }}
     # Do not run simultaneous builds
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ inputs.environment || 'development' }}-${{ github.ref }}
       cancel-in-progress: false
 
     steps:


### PR DESCRIPTION
Currently deployments are done in sequence even when they do not target the same env. 

This changes the concurrency key so that two deployments from main can be done in parallel to 2 different envs.