### PR TITLE
fix: update admin users page and header

### DIFF
--- a/lib/admin/accounts.ex
+++ b/lib/admin/accounts.ex
@@ -88,7 +88,6 @@ defmodule Admin.Accounts do
            |> User.email_changeset(attrs)
            |> Repo.insert() do
       broadcast_users({:created, user})
-      Logger.info("sent a broadcast message for #{inspect(user)}")
       {:ok, user}
     end
   end

--- a/lib/admin_web/components/layouts.ex
+++ b/lib/admin_web/components/layouts.ex
@@ -160,7 +160,6 @@ defmodule AdminWeb.Layouts do
               tabindex="0"
               class="menu menu-sm dropdown-content bg-base-100 rounded-box z-1 mt-3 w-52 p-2 shadow"
             >
-              <li><.link navigate={~p"/users"}>Users</.link></li>
               <li>
                 <.link navigate={~p"/published_items"}>Publications</.link>
                 <ul class="p-2">
@@ -170,14 +169,18 @@ defmodule AdminWeb.Layouts do
               </li>
               <li><.link navigate={~p"/publishers"}>Apps</.link></li>
               <li><.link navigate={~p"/notifications"}>Mailing</.link></li>
-              <li><.link navigate={~p"/users/settings"}>Settings</.link></li>
+              <li><.link navigate={~p"/users"}>Admins</.link></li>
               <li><.link navigate={~p"/oban"}>Oban</.link></li>
               <div class="divider m-0"></div>
-              <div class="flex flex-col items-center">
+              <div class="flex flex-col items-center gap-1">
                 <%= if @current_scope do %>
                   <span>{@current_scope.user.email}</span>
-                  <.link class="btn btn-ghost" href={~p"/users/log-out"} method="delete">
-                    Log out
+
+                  <.link class="btn btn-soft" navigate={~p"/users/settings"}>
+                    <.icon name="hero-cog" class="size-5 " /> Settings
+                  </.link>
+                  <.link class="btn btn-soft" href={~p"/users/log-out"} method="delete">
+                    <.icon name="hero-arrow-right-on-rectangle" class="size-5 " /> Log out
                   </.link>
                 <% else %>
                   <.link class="btn btn-ghost" href={~p"/users/log-in"}>Log in</.link>
@@ -194,7 +197,6 @@ defmodule AdminWeb.Layouts do
       <div class="navbar-center hidden lg:flex">
         <ul class="menu menu-horizontal px-1">
           <%= if @current_scope do %>
-            <li><.link navigate={~p"/users"}>Users</.link></li>
             <li>
               <details>
                 <summary>Publications</summary>
@@ -206,16 +208,22 @@ defmodule AdminWeb.Layouts do
             </li>
             <li><.link navigate={~p"/publishers"}>Apps</.link></li>
             <li><.link navigate={~p"/notifications"}>Mailing</.link></li>
-            <li><.link navigate={~p"/users/settings"}>Settings</.link></li>
+            <li><.link navigate={~p"/users"}>Admins</.link></li>
+
             <li><.link navigate={~p"/oban"}>Oban</.link></li>
           <% end %>
         </ul>
       </div>
       <div class="navbar-end gap-1">
-        <div class="hidden items-center lg:flex">
+        <div class="hidden items-center lg:flex gap-2">
           <%= if @current_scope do %>
             <span>{@current_scope.user.email}</span>
-            <.link class="btn btn-ghost" href={~p"/users/log-out"} method="delete">Log out</.link>
+            <.link class="btn btn-circle" navigate={~p"/users/settings"} title="Settings">
+              <.icon name="hero-cog" class="size-5 " />
+            </.link>
+            <.link class="btn btn-circle" href={~p"/users/log-out"} title="Log out" method="delete">
+              <.icon name="hero-arrow-right-on-rectangle" class="size-5 " />
+            </.link>
           <% else %>
             <.link class="btn btn-ghost" href={~p"/users/log-in"}>Log in</.link>
           <% end %>

--- a/lib/admin_web/live/user_live/form.ex
+++ b/lib/admin_web/live/user_live/form.ex
@@ -7,7 +7,12 @@ defmodule AdminWeb.UserLive.Form do
   def render(assigns) do
     ~H"""
     <Layouts.admin flash={@flash} current_scope={@current_scope}>
-      <.header>Create a new User</.header>
+      <.header>
+        Create a new admin user
+        <:subtitle>
+          This user will have admin privileges. They will be able to manage applications, publications and send email to graasp members.
+        </:subtitle>
+      </.header>
 
       <.form id="user_form" for={@form} phx-submit="save" phx-change="validate">
         <.input

--- a/lib/admin_web/live/user_live/listing.ex
+++ b/lib/admin_web/live/user_live/listing.ex
@@ -10,13 +10,10 @@ defmodule AdminWeb.UserLive.Listing do
     <Layouts.admin flash={@flash} current_scope={@current_scope}>
       <div class="">
         <.header>
-          List users
+          Admin users
           <:subtitle>Show users that are currently registered in the app</:subtitle>
           <:actions>
-            <.button phx-click="new_random_user" id="new_random_user">New Random User</.button>
-          </:actions>
-          <:actions>
-            <.button navigate={~p"/users/new"} id="new_user">New User</.button>
+            <.button navigate={~p"/users/new"} id="new_user">Add an admin user</.button>
           </:actions>
         </.header>
       </div>
@@ -72,7 +69,7 @@ defmodule AdminWeb.UserLive.Listing do
 
     socket =
       socket
-      |> assign(:page_title, "Users")
+      |> assign(:page_title, "Admin Users")
       |> stream(:users, Accounts.list_users())
       |> assign(:show_modal, false)
       |> assign(:user_to_delete, nil)

--- a/test/admin_web/live/user_live/form_test.exs
+++ b/test/admin_web/live/user_live/form_test.exs
@@ -8,7 +8,7 @@ defmodule AdminWeb.UserLive.FormTest do
     test "renders form for new user", %{conn: conn} do
       {:ok, lv, html} = live(conn, ~p"/users/new")
 
-      assert html =~ "Create a new User"
+      assert html =~ "Create a new admin user"
       assert has_element?(lv, "form")
 
       assert form(lv, "#user_form", user: %{email: "test@example.com"})

--- a/test/admin_web/live/user_live/listing_test.exs
+++ b/test/admin_web/live/user_live/listing_test.exs
@@ -9,7 +9,7 @@ defmodule AdminWeb.UserLive.ListingTest do
 
     test "Shows users", %{conn: conn} do
       {:ok, _lv, html} = live(conn, ~p"/users")
-      assert html =~ "List users"
+      assert html =~ "Admin users"
     end
 
     test "Delete user with confirmation dialog", %{conn: conn} do
@@ -29,9 +29,20 @@ defmodule AdminWeb.UserLive.ListingTest do
 
     test "Add user", %{conn: conn} do
       {:ok, lv, _html} = live(conn, ~p"/users")
-      lv |> element("#new_random_user") |> render_click()
 
-      assert render(lv) =~ "New user created"
+      assert {:ok, form_live, _} =
+               lv
+               |> element("#new_user")
+               |> render_click()
+               |> follow_redirect(conn, ~p"/users/new")
+
+      assert {:ok, index_live, _} =
+               form_live
+               |> form("#user_form", user: %{email: "test@example.com"})
+               |> render_submit()
+               |> follow_redirect(conn, ~p"/users")
+
+      assert render(index_live) =~ "User registered"
     end
   end
 end

--- a/test/admin_web/live/user_live/user_listing_test.exs
+++ b/test/admin_web/live/user_live/user_listing_test.exs
@@ -8,7 +8,7 @@ defmodule AdminWeb.UserLive.UserListingTest do
     test "render user list", %{conn: conn} do
       {:ok, _lv, html} = conn |> log_in_user(user_fixture()) |> live(~p"/users")
 
-      assert html =~ "List users"
+      assert html =~ "Admin users"
     end
 
     test "redirects if user is not logged in", %{conn: conn} do


### PR DESCRIPTION
In this PR:
- update the header bar
  - Settings are now on the right side as an icon and in the burger as a button next to "Log out"
- improve the admin users page
  - remove the "add random user" button
  - use "admin" instead of "user" to make it clear these are admin users and not normal graasp users

<img width="1452" height="275" alt="Screenshot 2025-12-08 at 10 46 46" src="https://github.com/user-attachments/assets/d1ff6b2b-1c56-43a2-b392-3044769719b7" />
<img width="601" height="459" alt="Screenshot 2025-12-08 at 10 46 58" src="https://github.com/user-attachments/assets/5a5617d8-89f2-47c3-a912-7681a5ed47b7" />
