### PR TITLE
fix: add an uptime command

### DIFF
--- a/lib/admin/release.ex
+++ b/lib/admin/release.ex
@@ -35,7 +35,7 @@ defmodule Admin.Release do
   end
 
   def uptime do
-    Uptime.print()
+    IO.puts(Uptime.print())
   end
 
   defp print_migrations_for(repo) do

--- a/lib/admin/tools/uptime.ex
+++ b/lib/admin/tools/uptime.ex
@@ -6,8 +6,7 @@ defmodule Admin.Tools.Uptime do
   def print do
     # get the total time from the Erlang VM
     {total_milisecond, _} = :erlang.statistics(:wall_clock)
-    formatted_uptime = hh_mm_ss(div(total_milisecond, 1_000))
-    IO.puts("Uptime: #{formatted_uptime}")
+    hh_mm_ss(div(total_milisecond, 1_000))
   end
 
   defp hh_mm_ss(seconds) do


### PR DESCRIPTION
In this PR I add an `uptime` command, so we can see how long the service has been running:
`Admin.Tools.Uptime.print()` from the remote console will show the time nicely formatted for humans in days, hours, minutes, seconds