### PR TITLE
chore(mise): use named arguments for `restart` task

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -8,8 +8,11 @@ aws logs tail '/ecs/admin' --follow --profile $1
 '''
 
 [tasks.restart]
+usage = '''
+arg "profile" "AWS profile name" default="dev"
+'''
 run = '''
-aws ecs update-service --cluster graasp-$1 --service admin --force-new-deployment --profile $1
+aws ecs update-service --cluster graasp-$usage_profile --service admin --force-new-deployment --profile $usage_profile
 '''
 
 [tasks.remote]


### PR DESCRIPTION
In this PR I fix the mise task that allows to restart a service in AWS.

It should use named arguments in order to work as expected.
