### PR TITLE
fix: href for "Support" link in footer should point to `/docs`

### DIFF
--- a/lib/admin_web/controllers/landing_html.ex
+++ b/lib/admin_web/controllers/landing_html.ex
@@ -482,10 +482,10 @@ defmodule AdminWeb.LandingHTML do
                 {dgettext("landing", "Home")}
               </.footer_link>
 
-              <.footer_link href="/about-us">
+              <.footer_link href={~p"/about-us"}>
                 {dgettext("landing", "About Us")}
               </.footer_link>
-              <.footer_link href="/support">
+              <.footer_link href={~p"/docs"}>
                 {dgettext("landing", "Support")}
               </.footer_link>
               <.footer_link href={~p"/contact"}>


### PR DESCRIPTION
close #172 