### PR TITLE
chore(ci): always restart service after deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -81,7 +81,6 @@ jobs:
         shell: bash
 
       - name: Restart Service
-        if: ${{ inputs.environment != 'production' }}
         run: |
           aws ecs update-service --cluster graasp-dev --service admin --force-new-deployment
         shell: bash


### PR DESCRIPTION
This will allow faster deploys and not having to remember to restart the service after the deployment