### PR TITLE
fix: accessibility issues detected on the landing page

### DIFF
--- a/lib/admin_web/components/layouts.ex
+++ b/lib/admin_web/components/layouts.ex
@@ -189,7 +189,12 @@ defmodule AdminWeb.Layouts do
 
   defp burger_menu(assigns) do
     ~H"""
-    <div tabindex="0" role="button" class="btn btn-ghost lg:hidden">
+    <div
+      tabindex="0"
+      role="button"
+      aria-label={gettext("Open navigation menu")}
+      class="btn btn-ghost lg:hidden"
+    >
       <svg
         xmlns="http://www.w3.org/2000/svg"
         class="h-5 w-5"

--- a/lib/admin_web/controllers/landing_html.ex
+++ b/lib/admin_web/controllers/landing_html.ex
@@ -563,17 +563,19 @@ defmodule AdminWeb.LandingHTML do
               <.footer_link href={AdminWeb.Marketing.disclaimer_path()}>
                 {dgettext("landing", "Disclaimer")}
               </.footer_link>
-              <div class="text-primary">
+              <div class="text-white">
                 <.form
                   for={@locale_form}
                   action={~p"/locale"}
                   method="post"
                 >
                   <.input
+                    label={gettext("Language")}
                     onchange="this.form.submit()"
                     type="select"
                     field={@locale_form[:locale]}
                     options={Languages.all_options()}
+                    class="w-full select text-primary"
                   />
                 </.form>
               </div>

--- a/lib/admin_web/controllers/landing_html/index.html.heex
+++ b/lib/admin_web/controllers/landing_html/index.html.heex
@@ -136,9 +136,9 @@
         </:action>
 
         <div class="flex flex-col gap-6">
-          <h5 class="text-md text-primary font-bold lg:text-lg ">
+          <h3 class="text-md text-primary font-bold lg:text-lg ">
             {dgettext("landing", "Compose your learning material with interactive content")}
-          </h5>
+          </h3>
           <div class="flex flex-row gap-2 lg:gap-4 w-full">
             <AdminWeb.Components.ItemTypes.image />
             <AdminWeb.Components.ItemTypes.audio />
@@ -232,9 +232,9 @@
         </:action>
 
         <div class="flex flex-col gap-6">
-          <h5 class="text-md text-primary font-bold lg:text-lg ">
+          <h3 class="text-md text-primary font-bold lg:text-lg ">
             {dgettext("landing", "Check out real activities from our users")}
-          </h5>
+          </h3>
 
           <div class="grid grid-cols-3 lg:grid-cols-6 gap-4 lg:gap-4 w-full">
             <%= for collection <- AdminWeb.LandingHTML.collections(Gettext.get_locale(AdminWeb.Gettext)) do %>
@@ -262,7 +262,7 @@
           </p>
           <.link
             class="btn btn-primary btn-soft"
-            href="mailto:support@graasp.org"
+            href={~p"/contact"}
             data-umami-event="need-support-button"
           >
             {dpgettext("landing", "link", "Contact us")}
@@ -296,13 +296,13 @@
             )}
           </p>
           <:action>
-            <a
+            <.link
               class="btn btn-primary btn-soft"
               data-umami-event="missions-contact-us-button"
               href={~p"/contact"}
             >
               {dpgettext("landing", "link", "Contact us")}
-            </a>
+            </.link>
           </:action>
         </.mission_card>
 

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -59,44 +59,44 @@ msgstr "Mehr lesen"
 msgid "Recent Posts"
 msgstr "Neueste Beiträge"
 
-#: lib/admin_web/components/layouts.ex:350
-#: lib/admin_web/components/layouts.ex:380
+#: lib/admin_web/components/layouts.ex:355
+#: lib/admin_web/components/layouts.ex:385
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr "Administration"
 
-#: lib/admin_web/components/layouts.ex:338
-#: lib/admin_web/components/layouts.ex:372
+#: lib/admin_web/components/layouts.ex:343
+#: lib/admin_web/components/layouts.ex:377
 #, elixir-autogen, elixir-format
 msgid "Blog"
 msgstr "Blog"
 
-#: lib/admin_web/components/layouts.ex:357
-#: lib/admin_web/components/layouts.ex:389
+#: lib/admin_web/components/layouts.ex:362
+#: lib/admin_web/components/layouts.ex:394
 #, elixir-autogen, elixir-format
 msgid "Get started"
 msgstr "Jetzt starten"
 
-#: lib/admin_web/components/layouts.ex:335
-#: lib/admin_web/components/layouts.ex:371
+#: lib/admin_web/components/layouts.ex:340
+#: lib/admin_web/components/layouts.ex:376
 #, elixir-autogen, elixir-format
 msgid "Library"
 msgstr "Bibliothek"
 
-#: lib/admin_web/components/layouts.ex:361
-#: lib/admin_web/components/layouts.ex:393
+#: lib/admin_web/components/layouts.ex:366
+#: lib/admin_web/components/layouts.ex:398
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Einloggen"
 
-#: lib/admin_web/components/layouts.ex:344
-#: lib/admin_web/components/layouts.ex:376
+#: lib/admin_web/components/layouts.ex:349
+#: lib/admin_web/components/layouts.ex:381
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Über uns"
 
-#: lib/admin_web/components/layouts.ex:347
-#: lib/admin_web/components/layouts.ex:377
+#: lib/admin_web/components/layouts.ex:352
+#: lib/admin_web/components/layouts.ex:382
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Kontakt"
@@ -271,8 +271,8 @@ msgctxt "page_title"
 msgid "Documentation"
 msgstr "Dokumentation"
 
-#: lib/admin_web/components/layouts.ex:341
-#: lib/admin_web/components/layouts.ex:374
+#: lib/admin_web/components/layouts.ex:346
+#: lib/admin_web/components/layouts.ex:379
 #, elixir-autogen, elixir-format
 msgid "Support"
 msgstr "Hilfe"
@@ -331,4 +331,14 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgctxt "documentation section"
 msgid "intro"
+msgstr ""
+
+#: lib/admin_web/controllers/landing_html.ex:573
+#, elixir-autogen, elixir-format
+msgid "Language"
+msgstr ""
+
+#: lib/admin_web/components/layouts.ex:195
+#, elixir-autogen, elixir-format
+msgid "Open navigation menu"
 msgstr ""

--- a/priv/gettext/de/LC_MESSAGES/landing.po
+++ b/priv/gettext/de/LC_MESSAGES/landing.po
@@ -51,7 +51,7 @@ msgstr "Haftungsausschluss"
 msgid "Home"
 msgstr "Startseite"
 
-#: lib/admin_web/controllers/landing_html.ex:595
+#: lib/admin_web/controllers/landing_html.ex:597
 #, elixir-autogen, elixir-format
 msgid "Idea illustrations by Storyset"
 msgstr "Ideenillustrationen von Storyset"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -59,44 +59,44 @@ msgstr ""
 msgid "Recent Posts"
 msgstr ""
 
-#: lib/admin_web/components/layouts.ex:350
-#: lib/admin_web/components/layouts.ex:380
+#: lib/admin_web/components/layouts.ex:355
+#: lib/admin_web/components/layouts.ex:385
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr ""
 
-#: lib/admin_web/components/layouts.ex:338
-#: lib/admin_web/components/layouts.ex:372
+#: lib/admin_web/components/layouts.ex:343
+#: lib/admin_web/components/layouts.ex:377
 #, elixir-autogen, elixir-format
 msgid "Blog"
 msgstr ""
 
-#: lib/admin_web/components/layouts.ex:357
-#: lib/admin_web/components/layouts.ex:389
+#: lib/admin_web/components/layouts.ex:362
+#: lib/admin_web/components/layouts.ex:394
 #, elixir-autogen, elixir-format
 msgid "Get started"
 msgstr ""
 
-#: lib/admin_web/components/layouts.ex:335
-#: lib/admin_web/components/layouts.ex:371
+#: lib/admin_web/components/layouts.ex:340
+#: lib/admin_web/components/layouts.ex:376
 #, elixir-autogen, elixir-format
 msgid "Library"
 msgstr ""
 
-#: lib/admin_web/components/layouts.ex:361
-#: lib/admin_web/components/layouts.ex:393
+#: lib/admin_web/components/layouts.ex:366
+#: lib/admin_web/components/layouts.ex:398
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr ""
 
-#: lib/admin_web/components/layouts.ex:344
-#: lib/admin_web/components/layouts.ex:376
+#: lib/admin_web/components/layouts.ex:349
+#: lib/admin_web/components/layouts.ex:381
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
 
-#: lib/admin_web/components/layouts.ex:347
-#: lib/admin_web/components/layouts.ex:377
+#: lib/admin_web/components/layouts.ex:352
+#: lib/admin_web/components/layouts.ex:382
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr ""
@@ -271,8 +271,8 @@ msgctxt "page_title"
 msgid "Documentation"
 msgstr ""
 
-#: lib/admin_web/components/layouts.ex:341
-#: lib/admin_web/components/layouts.ex:374
+#: lib/admin_web/components/layouts.ex:346
+#: lib/admin_web/components/layouts.ex:379
 #, elixir-autogen, elixir-format
 msgid "Support"
 msgstr ""
@@ -331,4 +331,14 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgctxt "documentation section"
 msgid "intro"
+msgstr ""
+
+#: lib/admin_web/controllers/landing_html.ex:573
+#, elixir-autogen, elixir-format
+msgid "Language"
+msgstr ""
+
+#: lib/admin_web/components/layouts.ex:195
+#, elixir-autogen, elixir-format
+msgid "Open navigation menu"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -59,44 +59,44 @@ msgstr "Read more"
 msgid "Recent Posts"
 msgstr "Recent Posts"
 
-#: lib/admin_web/components/layouts.ex:350
-#: lib/admin_web/components/layouts.ex:380
+#: lib/admin_web/components/layouts.ex:355
+#: lib/admin_web/components/layouts.ex:385
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr "Admin"
 
-#: lib/admin_web/components/layouts.ex:338
-#: lib/admin_web/components/layouts.ex:372
+#: lib/admin_web/components/layouts.ex:343
+#: lib/admin_web/components/layouts.ex:377
 #, elixir-autogen, elixir-format
 msgid "Blog"
 msgstr "Blog"
 
-#: lib/admin_web/components/layouts.ex:357
-#: lib/admin_web/components/layouts.ex:389
+#: lib/admin_web/components/layouts.ex:362
+#: lib/admin_web/components/layouts.ex:394
 #, elixir-autogen, elixir-format
 msgid "Get started"
 msgstr "Get started"
 
-#: lib/admin_web/components/layouts.ex:335
-#: lib/admin_web/components/layouts.ex:371
+#: lib/admin_web/components/layouts.ex:340
+#: lib/admin_web/components/layouts.ex:376
 #, elixir-autogen, elixir-format
 msgid "Library"
 msgstr "Library"
 
-#: lib/admin_web/components/layouts.ex:361
-#: lib/admin_web/components/layouts.ex:393
+#: lib/admin_web/components/layouts.ex:366
+#: lib/admin_web/components/layouts.ex:398
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Log in"
 
-#: lib/admin_web/components/layouts.ex:344
-#: lib/admin_web/components/layouts.ex:376
+#: lib/admin_web/components/layouts.ex:349
+#: lib/admin_web/components/layouts.ex:381
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "About"
 
-#: lib/admin_web/components/layouts.ex:347
-#: lib/admin_web/components/layouts.ex:377
+#: lib/admin_web/components/layouts.ex:352
+#: lib/admin_web/components/layouts.ex:382
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Contact"
@@ -271,8 +271,8 @@ msgctxt "page_title"
 msgid "Documentation"
 msgstr "Documentation"
 
-#: lib/admin_web/components/layouts.ex:341
-#: lib/admin_web/components/layouts.ex:374
+#: lib/admin_web/components/layouts.ex:346
+#: lib/admin_web/components/layouts.ex:379
 #, elixir-autogen, elixir-format
 msgid "Support"
 msgstr ""
@@ -331,4 +331,14 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgctxt "documentation section"
 msgid "intro"
+msgstr ""
+
+#: lib/admin_web/controllers/landing_html.ex:573
+#, elixir-autogen, elixir-format
+msgid "Language"
+msgstr ""
+
+#: lib/admin_web/components/layouts.ex:195
+#, elixir-autogen, elixir-format
+msgid "Open navigation menu"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/landing.po
+++ b/priv/gettext/en/LC_MESSAGES/landing.po
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: lib/admin_web/controllers/landing_html.ex:595
+#: lib/admin_web/controllers/landing_html.ex:597
 #, elixir-autogen, elixir-format
 msgid "Idea illustrations by Storyset"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -59,44 +59,44 @@ msgstr "Leer más"
 msgid "Recent Posts"
 msgstr "Entradas recientes"
 
-#: lib/admin_web/components/layouts.ex:350
-#: lib/admin_web/components/layouts.ex:380
+#: lib/admin_web/components/layouts.ex:355
+#: lib/admin_web/components/layouts.ex:385
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr "Administración"
 
-#: lib/admin_web/components/layouts.ex:338
-#: lib/admin_web/components/layouts.ex:372
+#: lib/admin_web/components/layouts.ex:343
+#: lib/admin_web/components/layouts.ex:377
 #, elixir-autogen, elixir-format
 msgid "Blog"
 msgstr "Blog"
 
-#: lib/admin_web/components/layouts.ex:357
-#: lib/admin_web/components/layouts.ex:389
+#: lib/admin_web/components/layouts.ex:362
+#: lib/admin_web/components/layouts.ex:394
 #, elixir-autogen, elixir-format
 msgid "Get started"
 msgstr "Empezar"
 
-#: lib/admin_web/components/layouts.ex:335
-#: lib/admin_web/components/layouts.ex:371
+#: lib/admin_web/components/layouts.ex:340
+#: lib/admin_web/components/layouts.ex:376
 #, elixir-autogen, elixir-format
 msgid "Library"
 msgstr "Biblioteca"
 
-#: lib/admin_web/components/layouts.ex:361
-#: lib/admin_web/components/layouts.ex:393
+#: lib/admin_web/components/layouts.ex:366
+#: lib/admin_web/components/layouts.ex:398
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Acceso"
 
-#: lib/admin_web/components/layouts.ex:344
-#: lib/admin_web/components/layouts.ex:376
+#: lib/admin_web/components/layouts.ex:349
+#: lib/admin_web/components/layouts.ex:381
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Acerca de"
 
-#: lib/admin_web/components/layouts.ex:347
-#: lib/admin_web/components/layouts.ex:377
+#: lib/admin_web/components/layouts.ex:352
+#: lib/admin_web/components/layouts.ex:382
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Contacto"
@@ -271,8 +271,8 @@ msgctxt "page_title"
 msgid "Documentation"
 msgstr "Documentación"
 
-#: lib/admin_web/components/layouts.ex:341
-#: lib/admin_web/components/layouts.ex:374
+#: lib/admin_web/components/layouts.ex:346
+#: lib/admin_web/components/layouts.ex:379
 #, elixir-autogen, elixir-format
 msgid "Support"
 msgstr "Apoyo"
@@ -331,4 +331,14 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgctxt "documentation section"
 msgid "intro"
+msgstr ""
+
+#: lib/admin_web/controllers/landing_html.ex:573
+#, elixir-autogen, elixir-format
+msgid "Language"
+msgstr ""
+
+#: lib/admin_web/components/layouts.ex:195
+#, elixir-autogen, elixir-format
+msgid "Open navigation menu"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/landing.po
+++ b/priv/gettext/es/LC_MESSAGES/landing.po
@@ -51,7 +51,7 @@ msgstr "Descargo de responsabilidad"
 msgid "Home"
 msgstr "Hogar"
 
-#: lib/admin_web/controllers/landing_html.ex:595
+#: lib/admin_web/controllers/landing_html.ex:597
 #, elixir-autogen, elixir-format
 msgid "Idea illustrations by Storyset"
 msgstr "Ilustraciones de ideas de Storyset"

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -59,44 +59,44 @@ msgstr "Lire plus"
 msgid "Recent Posts"
 msgstr "Articles récents"
 
-#: lib/admin_web/components/layouts.ex:350
-#: lib/admin_web/components/layouts.ex:380
+#: lib/admin_web/components/layouts.ex:355
+#: lib/admin_web/components/layouts.ex:385
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr "Admin"
 
-#: lib/admin_web/components/layouts.ex:338
-#: lib/admin_web/components/layouts.ex:372
+#: lib/admin_web/components/layouts.ex:343
+#: lib/admin_web/components/layouts.ex:377
 #, elixir-autogen, elixir-format
 msgid "Blog"
 msgstr "Blog"
 
-#: lib/admin_web/components/layouts.ex:357
-#: lib/admin_web/components/layouts.ex:389
+#: lib/admin_web/components/layouts.ex:362
+#: lib/admin_web/components/layouts.ex:394
 #, elixir-autogen, elixir-format
 msgid "Get started"
 msgstr "Commencer"
 
-#: lib/admin_web/components/layouts.ex:335
-#: lib/admin_web/components/layouts.ex:371
+#: lib/admin_web/components/layouts.ex:340
+#: lib/admin_web/components/layouts.ex:376
 #, elixir-autogen, elixir-format
 msgid "Library"
 msgstr "Library"
 
-#: lib/admin_web/components/layouts.ex:361
-#: lib/admin_web/components/layouts.ex:393
+#: lib/admin_web/components/layouts.ex:366
+#: lib/admin_web/components/layouts.ex:398
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Se connecter"
 
-#: lib/admin_web/components/layouts.ex:344
-#: lib/admin_web/components/layouts.ex:376
+#: lib/admin_web/components/layouts.ex:349
+#: lib/admin_web/components/layouts.ex:381
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "À propos"
 
-#: lib/admin_web/components/layouts.ex:347
-#: lib/admin_web/components/layouts.ex:377
+#: lib/admin_web/components/layouts.ex:352
+#: lib/admin_web/components/layouts.ex:382
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Contact"
@@ -271,8 +271,8 @@ msgctxt "page_title"
 msgid "Documentation"
 msgstr "Documentation"
 
-#: lib/admin_web/components/layouts.ex:341
-#: lib/admin_web/components/layouts.ex:374
+#: lib/admin_web/components/layouts.ex:346
+#: lib/admin_web/components/layouts.ex:379
 #, elixir-autogen, elixir-format
 msgid "Support"
 msgstr "Soutien"
@@ -331,4 +331,14 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgctxt "documentation section"
 msgid "intro"
+msgstr ""
+
+#: lib/admin_web/controllers/landing_html.ex:573
+#, elixir-autogen, elixir-format
+msgid "Language"
+msgstr ""
+
+#: lib/admin_web/components/layouts.ex:195
+#, elixir-autogen, elixir-format
+msgid "Open navigation menu"
 msgstr ""

--- a/priv/gettext/fr/LC_MESSAGES/landing.po
+++ b/priv/gettext/fr/LC_MESSAGES/landing.po
@@ -51,7 +51,7 @@ msgstr "Clause de non-responsabilité"
 msgid "Home"
 msgstr "Accueil"
 
-#: lib/admin_web/controllers/landing_html.ex:595
+#: lib/admin_web/controllers/landing_html.ex:597
 #, elixir-autogen, elixir-format
 msgid "Idea illustrations by Storyset"
 msgstr "Illustrations par Storyset"

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -59,44 +59,44 @@ msgstr "Per saperne di più"
 msgid "Recent Posts"
 msgstr "Articoli recenti"
 
-#: lib/admin_web/components/layouts.ex:350
-#: lib/admin_web/components/layouts.ex:380
+#: lib/admin_web/components/layouts.ex:355
+#: lib/admin_web/components/layouts.ex:385
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr "Amministratore"
 
-#: lib/admin_web/components/layouts.ex:338
-#: lib/admin_web/components/layouts.ex:372
+#: lib/admin_web/components/layouts.ex:343
+#: lib/admin_web/components/layouts.ex:377
 #, elixir-autogen, elixir-format
 msgid "Blog"
 msgstr "Blog"
 
-#: lib/admin_web/components/layouts.ex:357
-#: lib/admin_web/components/layouts.ex:389
+#: lib/admin_web/components/layouts.ex:362
+#: lib/admin_web/components/layouts.ex:394
 #, elixir-autogen, elixir-format
 msgid "Get started"
 msgstr "Iniziare"
 
-#: lib/admin_web/components/layouts.ex:335
-#: lib/admin_web/components/layouts.ex:371
+#: lib/admin_web/components/layouts.ex:340
+#: lib/admin_web/components/layouts.ex:376
 #, elixir-autogen, elixir-format
 msgid "Library"
 msgstr "Biblioteca"
 
-#: lib/admin_web/components/layouts.ex:361
-#: lib/admin_web/components/layouts.ex:393
+#: lib/admin_web/components/layouts.ex:366
+#: lib/admin_web/components/layouts.ex:398
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Login"
 
-#: lib/admin_web/components/layouts.ex:344
-#: lib/admin_web/components/layouts.ex:376
+#: lib/admin_web/components/layouts.ex:349
+#: lib/admin_web/components/layouts.ex:381
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Di"
 
-#: lib/admin_web/components/layouts.ex:347
-#: lib/admin_web/components/layouts.ex:377
+#: lib/admin_web/components/layouts.ex:352
+#: lib/admin_web/components/layouts.ex:382
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Contatto"
@@ -271,8 +271,8 @@ msgctxt "page_title"
 msgid "Documentation"
 msgstr "Documentazione"
 
-#: lib/admin_web/components/layouts.ex:341
-#: lib/admin_web/components/layouts.ex:374
+#: lib/admin_web/components/layouts.ex:346
+#: lib/admin_web/components/layouts.ex:379
 #, elixir-autogen, elixir-format
 msgid "Support"
 msgstr "Supporto"
@@ -331,4 +331,14 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgctxt "documentation section"
 msgid "intro"
+msgstr ""
+
+#: lib/admin_web/controllers/landing_html.ex:573
+#, elixir-autogen, elixir-format
+msgid "Language"
+msgstr ""
+
+#: lib/admin_web/components/layouts.ex:195
+#, elixir-autogen, elixir-format
+msgid "Open navigation menu"
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/landing.po
+++ b/priv/gettext/it/LC_MESSAGES/landing.po
@@ -51,7 +51,7 @@ msgstr "Disclaimer"
 msgid "Home"
 msgstr "Casa"
 
-#: lib/admin_web/controllers/landing_html.ex:595
+#: lib/admin_web/controllers/landing_html.ex:597
 #, elixir-autogen, elixir-format
 msgid "Idea illustrations by Storyset"
 msgstr "Illustrazioni di idee di Storyset"

--- a/priv/gettext/landing.pot
+++ b/priv/gettext/landing.pot
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: lib/admin_web/controllers/landing_html.ex:595
+#: lib/admin_web/controllers/landing_html.ex:597
 #, elixir-autogen, elixir-format
 msgid "Idea illustrations by Storyset"
 msgstr ""


### PR DESCRIPTION
In this PR:

- add label to burger menu
- add label to language select
- use correct ordering of heading elements (h2, h3 instead of h2, h5)
- use consistent links when they have the same text
