### PR TITLE
fix: key is too long when emptying the trash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
-# Graasp Admin
+# Graasp web
 
 [![gitlocalized german](https://gitlocalize.com/repo/10639/de/badge.svg)](https://gitlocalize.com/repo/10639/de?utm_source=badge)
 [![gitlocalized french](https://gitlocalize.com/repo/10639/fr/badge.svg)](https://gitlocalize.com/repo/10639/fr?utm_source=badge)
 [![gitlocalized italian](https://gitlocalize.com/repo/10639/it/badge.svg)](https://gitlocalize.com/repo/10639/it?utm_source=badge)
 [![gitlocalized spanish](https://gitlocalize.com/repo/10639/es/badge.svg)](https://gitlocalize.com/repo/10639/es?utm_source=badge)
 
-This is the codebase for the Graasp admin platform written in [Elixir](https://elixir-lang.org/) using [the Phoenix web framework](https://phoenixframework.org).
+This is the codebase for the Graasp frontend and administration interface.
+It is written in [Elixir](https://elixir-lang.org/) using [the Phoenix web framework](https://phoenixframework.org).
 
 The admin platform enables administrators to:
 
@@ -28,7 +29,7 @@ mise i
 
 As of writing this, the following versions are used:
 
-- elixir: 1.19.4
+- elixir: 1.19.5
 - erlang: 28 (OTP 28)
 
 <details>
@@ -120,11 +121,62 @@ To debug failed tests: `iex -S mix test --failed --breakpoints --trace`
 
 ## Deployment
 
-The application is deployed using ECS. The deployment process is handled by the graasp/infrastrucutre repository.
+The application is deployed on AWS using ECS. The deployment process is handled by the graasp/infrastructure repository.
 It is in charge of registering the service and starting the tasks with the proper environment variables.
-This repo simply builds the docker images and pushes them to the private ECR registry.
+This repo simply builds the docker images and pushes them to the private ECR registry and requests a service update so that the new image is used by the service.
 
 Please checkout [the setup docs](./docs/setup.md) for more information on how to bootstrap a server to deploy your app in production.
+
+### Deploying with docker locally
+
+It is possible to run this application with docker compose in a "local" environment (i.e. not a cloud-provider like AWS).
+Below you will find all options that you can use to customize the application so that it runs without issues in docker compose:
+
+```yaml
+admin:
+  image: <image-name> # or public.ecr.aws/graasp/admin:v0.10.5
+  hostname: admin
+  environment:
+    # This depends on where your database is, this example uses a database in the same docker compose exposed as `db` host with graasper credentials
+    DATABASE_URL: postgres://graasper:graasper@db:5432/graasp
+    # The host that the application is running on, this is normally `graasp.org` but in local we use `localhost`
+    PHX_HOST: localhost
+    # The port that the application is running on (for the container network)
+    PORT: 4000
+    # The public port that the application is running on, can be different from the PORT if behind a reverse proxy
+    PUBLIC_PORT: 4000
+    # The protocol to use, default to `https`, in this case we want to force it to HTTP because we do not have a certificate
+    PROTOCOL: http
+    # The secret key base, generate one with: `mix phx.gen.secret`
+    SECRET_KEY_BASE: <secet value>
+    # The release cookie allows multiple instances of the app to communicate, genreate it via: `mix phx.gen.secret`
+    RELEASE_COOKIE: <secret value>
+    # The name of the files item bucket, refer to the core documentation on how to create the buckets in garage (s3-compatible storage)
+    FILE_ITEMS_BUCKET_NAME: file-items
+    # The name of the H5P bucket, same as for the file bucket, refer to the docs on how to create the bucket in garage
+    H5P_CONTENT_BUCKET_NAME: h5p-items
+    # AWS access key and secret, when using garage
+    AWS_ACCESS_KEY_ID: <secert value>
+    AWS_SECRET_ACCESS_KEY: <secret value>
+    # When using garage, set the region to `garage`
+    AWS_REGION: garage
+    # Override the protocol to use HTTP (in local we do not have HTTPS)
+    AWS_S3_SCHEME: http://
+    # The S3 host set for garage, override the aws default
+    AWS_S3_HOST: s3.garage.localhost
+    # The port that the s3 api responds to for garage
+    AWS_S3_PORT: 3900
+    # Override the Mailer adapter from AWS SES to use a simple SMTP server (either a local mailcatcher or external SMTP server)
+    MAILER_CONNECTION: smtp://docker:docker@mailer:1025
+  ports:
+    - "4000:4000"
+  links:
+    # This is necessary so that the s3 garage domain resolves to the container in the docker network
+    - garage:s3.garage.localhost
+  depends_on:
+    - core
+  restart: unless-stopped
+```
 
 ## Translations
 
@@ -174,6 +226,6 @@ Checkout [the memento](./docs/memento.md) for an overview of helpful commands fo
 
 ### Cleaning artifacts after making a release
 
-If you made a release localy it is possible that you end-up with a lot of files in the `priv/static/` folder.
+If you made a release locally it is possible that you end-up with a lot of files in the `priv/static/` folder.
 
 Before committing, run: `mix phx.digest.clean --all` to clean them.

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -18,6 +18,9 @@ config :logger, level: :info
 
 # Sentry configuration
 config :sentry,
+  # We do not set the DSN from a hard coded value so that it is possible to enable or disable it.
+  # To enable, simply provide an env var `SENTRY_DSN`
+  # To disable ensure no env var with `SENTRY_DSN` is set
   # dsn: "https://b4c2635dfa3bb58ad2cded33d1201e57@o244065.ingest.us.sentry.io/4509863475740672",
   release: Mix.Project.config()[:version],
   enable_source_code_context: true,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -18,7 +18,7 @@ config :logger, level: :info
 
 # Sentry configuration
 config :sentry,
-  dsn: "https://b4c2635dfa3bb58ad2cded33d1201e57@o244065.ingest.us.sentry.io/4509863475740672",
+  # dsn: "https://b4c2635dfa3bb58ad2cded33d1201e57@o244065.ingest.us.sentry.io/4509863475740672",
   release: Mix.Project.config()[:version],
   enable_source_code_context: true,
   root_source_code_paths: [File.cwd!()],

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -52,11 +52,13 @@ if config_env() == :prod do
 
   host = System.get_env("PHX_HOST") || "graasp.org"
   port = String.to_integer(System.get_env("PORT") || "4000")
+  protocol = System.get_env("PROTOCOL") || "https"
+  public_port = String.to_integer(System.get_env("PUBLIC_PORT") || "443")
 
   config :admin, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
 
   config :admin, AdminWeb.Endpoint,
-    url: [scheme: "https", host: host, port: 443],
+    url: [scheme: protocol, host: host, port: public_port],
     http: [
       # Enable IPv6 and bind on all interfaces.
       # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.
@@ -105,7 +107,21 @@ if config_env() == :prod do
   # In production you need to configure the mailer to use a different adapter.
   # Here is an example configuration for Mailgun:
   #
-  config :admin, Admin.Mailer, adapter: Swoosh.Adapters.ExAwsAmazonSES
+  if System.get_env("MAILER_CONNECTION") != nil do
+    # get credentials from the connection string
+    conn = System.get_env("MAILER_CONNECTION") |> URI.parse()
+    [username, password] = conn.userinfo |> String.split(":", parts: 2)
+
+    config :admin, Admin.Mailer,
+      adapter: Swoosh.Adapters.SMTP,
+      relay: conn.host,
+      port: conn.port,
+      username: username,
+      password: password,
+      ssl: System.get_env("MAILER_SSL") == "true"
+  else
+    config :admin, Admin.Mailer, adapter: Swoosh.Adapters.ExAwsAmazonSES
+  end
 
   #
   # Most non-SMTP adapters require an API client. Swoosh supports Req, Hackney,
@@ -133,7 +149,8 @@ if config_env() == :prod do
     end
 
   config :sentry,
-    environment_name: environment_name
+    environment_name: environment_name,
+    dsn: System.get_env("SENTRY_DSN")
 
   base_host =
     cond do
@@ -163,6 +180,9 @@ if config_env() == :prod do
 
   config :ex_aws, :s3,
     region: System.get_env("AWS_REGION", "eu-central-1"),
+    scheme: System.get_env("AWS_S3_SCHEME", "https"),
+    host: System.get_env("AWS_S3_HOST"),
+    port: System.get_env("AWS_S3_PORT", nil),
     # If using custom endpoints like LocalStack or MinIO, path_style: true is often necessary.
     path_style: true
 

--- a/lib/admin/h5p_items.ex
+++ b/lib/admin/h5p_items.ex
@@ -39,6 +39,12 @@ defmodule Admin.H5PItems do
   end
 
   defp delete_with_content_id(content_id) do
-    S3.delete_with_prefix(h5p_bucket(), "h5p-content/#{content_id}")
+    key = "h5p-content/#{content_id}"
+
+    if String.length(key) >= 1024 do
+      Logger.warning("ContentId '#{key}' is too long, skipping deletion")
+    else
+      S3.delete_with_prefix(h5p_bucket(), key)
+    end
   end
 end

--- a/lib/admin/item_files.ex
+++ b/lib/admin/item_files.ex
@@ -4,13 +4,23 @@ defmodule Admin.ItemFiles do
   """
   alias Admin.S3
 
+  require Logger
+
   defp file_bucket, do: Application.get_env(:admin, :file_items_bucket, "file-items")
 
-  def delete(files_data) do
+  def delete([]), do: :ok
+
+  def delete(files_data) when is_list(files_data) and length(files_data) > 0 do
     file_paths = files_data |> Enum.map(& &1.path)
-    {:ok, _} = S3.delete_objects(file_bucket(), file_paths)
-    file_ids = files_data |> Enum.map(& &1.id)
-    {:ok, _} = Admin.ItemThumbnails.delete_thumbnails(file_ids)
+    # key length can not exceed 1024 bytes
+    {valid_keys, _invalid_keys} = file_paths |> Enum.split_with(&(String.length(&1) <= 1023))
+    {:ok, _} = S3.delete_objects(file_bucket(), valid_keys)
+
+    files_data
+    |> Enum.each(fn file ->
+      {:ok, _} = Admin.ItemThumbnails.delete_thumbnails(file.id)
+    end)
+
     :ok
   end
 end

--- a/lib/admin/item_files.ex
+++ b/lib/admin/item_files.ex
@@ -10,7 +10,7 @@ defmodule Admin.ItemFiles do
 
   def delete([]), do: :ok
 
-  def delete(files_data) when is_list(files_data) and length(files_data) > 0 do
+  def delete(files_data) when is_list(files_data) and files_data != [] do
     file_paths = files_data |> Enum.map(& &1.path)
     # key length can not exceed 1024 bytes
     {valid_keys, _invalid_keys} = file_paths |> Enum.split_with(&(String.length(&1) <= 1023))

--- a/lib/admin/item_thumbnails.ex
+++ b/lib/admin/item_thumbnails.ex
@@ -20,7 +20,7 @@ defmodule Admin.ItemThumbnails do
     url
   end
 
-  def delete_thumbnails(item_id) do
+  def delete_thumbnails(item_id) when is_binary(item_id) do
     file_paths = [
       "thumbnails/#{item_id}/small",
       "thumbnails/#{item_id}/medium",

--- a/lib/admin/recycled_items.ex
+++ b/lib/admin/recycled_items.ex
@@ -4,6 +4,7 @@ defmodule Admin.RecycledItems do
   """
   import Ecto.Query, warn: false
 
+  alias Admin.Accounts.Scope
   alias Admin.RecycledItems.RecycledItemData
   alias Admin.Repo
 
@@ -55,5 +56,13 @@ defmodule Admin.RecycledItems do
   def trash(%{item_path: _item_path, creator_id: _creator_id} = attrs) do
     RecycledItemData.changeset(%RecycledItemData{}, attrs)
     |> Repo.insert!()
+  end
+
+  def subscribe_recycled_items(%Scope{} = _scope) do
+    Phoenix.PubSub.subscribe(Admin.PubSub, "recycled_items")
+  end
+
+  def report_cleanup_completion(message) do
+    Phoenix.PubSub.broadcast(Admin.PubSub, "recycled_items", message)
   end
 end

--- a/lib/admin/recycled_items/cleanup_worker.ex
+++ b/lib/admin/recycled_items/cleanup_worker.ex
@@ -44,6 +44,7 @@ defmodule Admin.TrashCleanupWorker do
     }
 
     Logger.info("Cleanup report: #{inspect(report)}")
+    Admin.RecycledItems.report_cleanup_completion({:completed, report})
 
     {:ok, report}
   end
@@ -62,6 +63,8 @@ defmodule Admin.TrashCleanupWorker do
         %{id: id, path: path || key}
       end)
       |> Enum.reject(fn %{path: path} -> path == nil end)
+
+    Admin.ItemFiles.delete(files_data)
 
     # delete file and thumbnails
     Admin.ItemFiles.delete(files_data)

--- a/lib/admin/recycled_items/cleanup_worker.ex
+++ b/lib/admin/recycled_items/cleanup_worker.ex
@@ -64,8 +64,6 @@ defmodule Admin.TrashCleanupWorker do
       end)
       |> Enum.reject(fn %{path: path} -> path == nil end)
 
-    Admin.ItemFiles.delete(files_data)
-
     # delete file and thumbnails
     Admin.ItemFiles.delete(files_data)
 

--- a/lib/admin/s3.ex
+++ b/lib/admin/s3.ex
@@ -72,7 +72,7 @@ defmodule Admin.S3 do
     {:ok, _} = S3.delete_object(bucket, key) |> @ex_aws_mod.request()
   end
 
-  def delete_objects(bucket, file_paths) when is_list(file_paths) and length(file_paths) > 0 do
+  def delete_objects(bucket, file_paths) when is_list(file_paths) and file_paths != [] do
     # keys can not be longer than 1024 bytes
     key_lengths = file_paths |> Enum.map(&String.length/1) |> Enum.max()
 

--- a/lib/admin/s3.ex
+++ b/lib/admin/s3.ex
@@ -72,7 +72,14 @@ defmodule Admin.S3 do
     {:ok, _} = S3.delete_object(bucket, key) |> @ex_aws_mod.request()
   end
 
-  def delete_objects(bucket, file_paths) do
+  def delete_objects(bucket, file_paths) when is_list(file_paths) and length(file_paths) > 0 do
+    # keys can not be longer than 1024 bytes
+    key_lengths = file_paths |> Enum.map(&String.length/1) |> Enum.max()
+
+    if key_lengths > 1024 do
+      raise "key length must be less than or equal to 1024 bytes, got: #{inspect(file_paths)}"
+    end
+
     {:ok, _} =
       S3.delete_all_objects(bucket, file_paths)
       |> @ex_aws_mod.request()

--- a/lib/admin_web/components/layouts.ex
+++ b/lib/admin_web/components/layouts.ex
@@ -242,6 +242,7 @@ defmodule AdminWeb.Layouts do
                 <span>Development</span>
                 <ul class="p-2">
                   <li><.link navigate={~p"/admin/about"}>About</.link></li>
+                  <li><.link navigate={~p"/admin/trash"}>Trash</.link></li>
                   <li><.link navigate={~p"/admin/oban"}>Job Queues</.link></li>
                   <li><.link navigate={~p"/admin/dev/dashboard"}>Live Dashboard</.link></li>
                 </ul>
@@ -296,6 +297,7 @@ defmodule AdminWeb.Layouts do
                 <summary>Development</summary>
                 <ul class="p-2">
                   <li><.link navigate={~p"/admin/about"}>About</.link></li>
+                  <li><.link navigate={~p"/admin/trash"}>Trash</.link></li>
                   <li><.link navigate={~p"/admin/oban"}>Job Queues</.link></li>
                   <li><.link navigate={~p"/admin/dev/dashboard"}>Live Dashboard</.link></li>
                 </ul>

--- a/lib/admin_web/live/trash_live/index.ex
+++ b/lib/admin_web/live/trash_live/index.ex
@@ -1,0 +1,78 @@
+defmodule AdminWeb.TrashLive.Index do
+  use AdminWeb, :live_view
+
+  def render(assigns) do
+    ~H"""
+    <Layouts.admin flash={@flash} current_scope={@current_scope}>
+      <h2 class="text-lg text-bold">Recycled items Statistics</h2>
+      <div class="stats stats-vertical sm:stats-horizontal shadow bg-base-100">
+        <StatisticsComponents.stat value={@recycled_stats.total} title="Overall">
+          Recycled items
+        </StatisticsComponents.stat>
+        <StatisticsComponents.stat value={@recycled_stats.scheduled} title="Scheduled for deletion">
+          Items trashed more than 3 months ago
+        </StatisticsComponents.stat>
+        <StatisticsComponents.stat value={@recycled_stats.pending} title="Pending">
+          Items in user trash for less than 3 months
+        </StatisticsComponents.stat>
+      </div>
+      <p class="text-sm text-muted">These statistics update every 20 seconds.</p>
+      <div class="mt-4">
+        <button phx-click="run_cleanup" class="btn btn-primary">Run Cleanup</button>
+      </div>
+      <div class="mt-4">
+        <%= if @cleanup_result do %>
+          <p>{inspect(@cleanup_result)}</p>
+        <% end %>
+      </div>
+    </Layouts.admin>
+    """
+  end
+
+  def mount(_params, _session, socket) do
+    if connected?(socket) do
+      Admin.RecycledItems.subscribe_recycled_items(socket.assigns.current_scope)
+    end
+
+    # update page every 20 seconds
+    :timer.send_interval(20_000, :update_stats)
+
+    socket =
+      socket
+      |> assign(:page_title, pgettext("page title", "Trash Management"))
+      |> assign(
+        :recycled_stats,
+        Admin.RecycledItems.get_stats()
+      )
+      |> assign(:cleanup_result, nil)
+
+    {:ok, socket}
+  end
+
+  def handle_event("run_cleanup", _params, socket) do
+    %{}
+    |> Admin.TrashCleanupWorker.new()
+    |> Oban.insert()
+
+    {:noreply, socket}
+  end
+
+  def handle_info(:update_stats, socket) do
+    socket =
+      socket
+      |> assign(
+        :recycled_stats,
+        Admin.RecycledItems.get_stats()
+      )
+
+    {:noreply, socket}
+  end
+
+  def handle_info({:completed, result}, socket) do
+    socket =
+      socket
+      |> assign(:cleanup_result, result)
+
+    {:noreply, socket}
+  end
+end

--- a/lib/admin_web/router.ex
+++ b/lib/admin_web/router.ex
@@ -197,6 +197,10 @@ defmodule AdminWeb.Router do
       scope "/test" do
         live "/sentry", TestLive.Sentry, :sentry
       end
+
+      scope "/trash" do
+        live "/", TrashLive.Index, :index
+      end
     end
 
     post "/users/update-password", UserSessionController, :update_password

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -59,44 +59,44 @@ msgstr "Mehr lesen"
 msgid "Recent Posts"
 msgstr "Neueste Beiträge"
 
-#: lib/admin_web/components/layouts.ex:359
-#: lib/admin_web/components/layouts.ex:389
+#: lib/admin_web/components/layouts.ex:361
+#: lib/admin_web/components/layouts.ex:391
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr "Administration"
 
-#: lib/admin_web/components/layouts.ex:347
-#: lib/admin_web/components/layouts.ex:381
+#: lib/admin_web/components/layouts.ex:349
+#: lib/admin_web/components/layouts.ex:383
 #, elixir-autogen, elixir-format
 msgid "Blog"
 msgstr "Blog"
 
-#: lib/admin_web/components/layouts.ex:366
-#: lib/admin_web/components/layouts.ex:398
+#: lib/admin_web/components/layouts.ex:368
+#: lib/admin_web/components/layouts.ex:400
 #, elixir-autogen, elixir-format
 msgid "Get started"
 msgstr "Jetzt starten"
 
-#: lib/admin_web/components/layouts.ex:344
-#: lib/admin_web/components/layouts.ex:380
+#: lib/admin_web/components/layouts.ex:346
+#: lib/admin_web/components/layouts.ex:382
 #, elixir-autogen, elixir-format
 msgid "Library"
 msgstr "Bibliothek"
 
-#: lib/admin_web/components/layouts.ex:370
-#: lib/admin_web/components/layouts.ex:402
+#: lib/admin_web/components/layouts.ex:372
+#: lib/admin_web/components/layouts.ex:404
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Einloggen"
 
-#: lib/admin_web/components/layouts.ex:353
-#: lib/admin_web/components/layouts.ex:385
+#: lib/admin_web/components/layouts.ex:355
+#: lib/admin_web/components/layouts.ex:387
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Über uns"
 
-#: lib/admin_web/components/layouts.ex:356
-#: lib/admin_web/components/layouts.ex:386
+#: lib/admin_web/components/layouts.ex:358
+#: lib/admin_web/components/layouts.ex:388
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Kontakt"
@@ -272,8 +272,8 @@ msgctxt "page_title"
 msgid "Documentation"
 msgstr "Dokumentation"
 
-#: lib/admin_web/components/layouts.ex:350
-#: lib/admin_web/components/layouts.ex:383
+#: lib/admin_web/components/layouts.ex:352
+#: lib/admin_web/components/layouts.ex:385
 #, elixir-autogen, elixir-format
 msgid "Support"
 msgstr "Hilfe"
@@ -342,4 +342,10 @@ msgstr ""
 #: lib/admin_web/components/layouts.ex:195
 #, elixir-autogen, elixir-format
 msgid "Open navigation menu"
+msgstr ""
+
+#: lib/admin_web/live/trash_live/index.ex:42
+#, elixir-autogen, elixir-format
+msgctxt "page title"
+msgid "Trash Management"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -59,44 +59,44 @@ msgstr ""
 msgid "Recent Posts"
 msgstr ""
 
-#: lib/admin_web/components/layouts.ex:359
-#: lib/admin_web/components/layouts.ex:389
+#: lib/admin_web/components/layouts.ex:361
+#: lib/admin_web/components/layouts.ex:391
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr ""
 
-#: lib/admin_web/components/layouts.ex:347
-#: lib/admin_web/components/layouts.ex:381
+#: lib/admin_web/components/layouts.ex:349
+#: lib/admin_web/components/layouts.ex:383
 #, elixir-autogen, elixir-format
 msgid "Blog"
 msgstr ""
 
-#: lib/admin_web/components/layouts.ex:366
-#: lib/admin_web/components/layouts.ex:398
+#: lib/admin_web/components/layouts.ex:368
+#: lib/admin_web/components/layouts.ex:400
 #, elixir-autogen, elixir-format
 msgid "Get started"
 msgstr ""
 
-#: lib/admin_web/components/layouts.ex:344
-#: lib/admin_web/components/layouts.ex:380
+#: lib/admin_web/components/layouts.ex:346
+#: lib/admin_web/components/layouts.ex:382
 #, elixir-autogen, elixir-format
 msgid "Library"
 msgstr ""
 
-#: lib/admin_web/components/layouts.ex:370
-#: lib/admin_web/components/layouts.ex:402
+#: lib/admin_web/components/layouts.ex:372
+#: lib/admin_web/components/layouts.ex:404
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr ""
 
-#: lib/admin_web/components/layouts.ex:353
-#: lib/admin_web/components/layouts.ex:385
+#: lib/admin_web/components/layouts.ex:355
+#: lib/admin_web/components/layouts.ex:387
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
 
-#: lib/admin_web/components/layouts.ex:356
-#: lib/admin_web/components/layouts.ex:386
+#: lib/admin_web/components/layouts.ex:358
+#: lib/admin_web/components/layouts.ex:388
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr ""
@@ -272,8 +272,8 @@ msgctxt "page_title"
 msgid "Documentation"
 msgstr ""
 
-#: lib/admin_web/components/layouts.ex:350
-#: lib/admin_web/components/layouts.ex:383
+#: lib/admin_web/components/layouts.ex:352
+#: lib/admin_web/components/layouts.ex:385
 #, elixir-autogen, elixir-format
 msgid "Support"
 msgstr ""
@@ -342,4 +342,10 @@ msgstr ""
 #: lib/admin_web/components/layouts.ex:195
 #, elixir-autogen, elixir-format
 msgid "Open navigation menu"
+msgstr ""
+
+#: lib/admin_web/live/trash_live/index.ex:42
+#, elixir-autogen, elixir-format
+msgctxt "page title"
+msgid "Trash Management"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -59,44 +59,44 @@ msgstr "Read more"
 msgid "Recent Posts"
 msgstr "Recent Posts"
 
-#: lib/admin_web/components/layouts.ex:359
-#: lib/admin_web/components/layouts.ex:389
+#: lib/admin_web/components/layouts.ex:361
+#: lib/admin_web/components/layouts.ex:391
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr "Admin"
 
-#: lib/admin_web/components/layouts.ex:347
-#: lib/admin_web/components/layouts.ex:381
+#: lib/admin_web/components/layouts.ex:349
+#: lib/admin_web/components/layouts.ex:383
 #, elixir-autogen, elixir-format
 msgid "Blog"
 msgstr "Blog"
 
-#: lib/admin_web/components/layouts.ex:366
-#: lib/admin_web/components/layouts.ex:398
+#: lib/admin_web/components/layouts.ex:368
+#: lib/admin_web/components/layouts.ex:400
 #, elixir-autogen, elixir-format
 msgid "Get started"
 msgstr "Get started"
 
-#: lib/admin_web/components/layouts.ex:344
-#: lib/admin_web/components/layouts.ex:380
+#: lib/admin_web/components/layouts.ex:346
+#: lib/admin_web/components/layouts.ex:382
 #, elixir-autogen, elixir-format
 msgid "Library"
 msgstr "Library"
 
-#: lib/admin_web/components/layouts.ex:370
-#: lib/admin_web/components/layouts.ex:402
+#: lib/admin_web/components/layouts.ex:372
+#: lib/admin_web/components/layouts.ex:404
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Log in"
 
-#: lib/admin_web/components/layouts.ex:353
-#: lib/admin_web/components/layouts.ex:385
+#: lib/admin_web/components/layouts.ex:355
+#: lib/admin_web/components/layouts.ex:387
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "About"
 
-#: lib/admin_web/components/layouts.ex:356
-#: lib/admin_web/components/layouts.ex:386
+#: lib/admin_web/components/layouts.ex:358
+#: lib/admin_web/components/layouts.ex:388
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Contact"
@@ -272,8 +272,8 @@ msgctxt "page_title"
 msgid "Documentation"
 msgstr "Documentation"
 
-#: lib/admin_web/components/layouts.ex:350
-#: lib/admin_web/components/layouts.ex:383
+#: lib/admin_web/components/layouts.ex:352
+#: lib/admin_web/components/layouts.ex:385
 #, elixir-autogen, elixir-format
 msgid "Support"
 msgstr ""
@@ -342,4 +342,10 @@ msgstr ""
 #: lib/admin_web/components/layouts.ex:195
 #, elixir-autogen, elixir-format
 msgid "Open navigation menu"
+msgstr ""
+
+#: lib/admin_web/live/trash_live/index.ex:42
+#, elixir-autogen, elixir-format
+msgctxt "page title"
+msgid "Trash Management"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -59,44 +59,44 @@ msgstr "Leer más"
 msgid "Recent Posts"
 msgstr "Entradas recientes"
 
-#: lib/admin_web/components/layouts.ex:359
-#: lib/admin_web/components/layouts.ex:389
+#: lib/admin_web/components/layouts.ex:361
+#: lib/admin_web/components/layouts.ex:391
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr "Administración"
 
-#: lib/admin_web/components/layouts.ex:347
-#: lib/admin_web/components/layouts.ex:381
+#: lib/admin_web/components/layouts.ex:349
+#: lib/admin_web/components/layouts.ex:383
 #, elixir-autogen, elixir-format
 msgid "Blog"
 msgstr "Blog"
 
-#: lib/admin_web/components/layouts.ex:366
-#: lib/admin_web/components/layouts.ex:398
+#: lib/admin_web/components/layouts.ex:368
+#: lib/admin_web/components/layouts.ex:400
 #, elixir-autogen, elixir-format
 msgid "Get started"
 msgstr "Empezar"
 
-#: lib/admin_web/components/layouts.ex:344
-#: lib/admin_web/components/layouts.ex:380
+#: lib/admin_web/components/layouts.ex:346
+#: lib/admin_web/components/layouts.ex:382
 #, elixir-autogen, elixir-format
 msgid "Library"
 msgstr "Biblioteca"
 
-#: lib/admin_web/components/layouts.ex:370
-#: lib/admin_web/components/layouts.ex:402
+#: lib/admin_web/components/layouts.ex:372
+#: lib/admin_web/components/layouts.ex:404
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Acceso"
 
-#: lib/admin_web/components/layouts.ex:353
-#: lib/admin_web/components/layouts.ex:385
+#: lib/admin_web/components/layouts.ex:355
+#: lib/admin_web/components/layouts.ex:387
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Acerca de"
 
-#: lib/admin_web/components/layouts.ex:356
-#: lib/admin_web/components/layouts.ex:386
+#: lib/admin_web/components/layouts.ex:358
+#: lib/admin_web/components/layouts.ex:388
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Contacto"
@@ -272,8 +272,8 @@ msgctxt "page_title"
 msgid "Documentation"
 msgstr "Documentación"
 
-#: lib/admin_web/components/layouts.ex:350
-#: lib/admin_web/components/layouts.ex:383
+#: lib/admin_web/components/layouts.ex:352
+#: lib/admin_web/components/layouts.ex:385
 #, elixir-autogen, elixir-format
 msgid "Support"
 msgstr "Apoyo"
@@ -342,4 +342,10 @@ msgstr ""
 #: lib/admin_web/components/layouts.ex:195
 #, elixir-autogen, elixir-format
 msgid "Open navigation menu"
+msgstr ""
+
+#: lib/admin_web/live/trash_live/index.ex:42
+#, elixir-autogen, elixir-format
+msgctxt "page title"
+msgid "Trash Management"
 msgstr ""

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -59,44 +59,44 @@ msgstr "Lire plus"
 msgid "Recent Posts"
 msgstr "Articles récents"
 
-#: lib/admin_web/components/layouts.ex:359
-#: lib/admin_web/components/layouts.ex:389
+#: lib/admin_web/components/layouts.ex:361
+#: lib/admin_web/components/layouts.ex:391
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr "Admin"
 
-#: lib/admin_web/components/layouts.ex:347
-#: lib/admin_web/components/layouts.ex:381
+#: lib/admin_web/components/layouts.ex:349
+#: lib/admin_web/components/layouts.ex:383
 #, elixir-autogen, elixir-format
 msgid "Blog"
 msgstr "Blog"
 
-#: lib/admin_web/components/layouts.ex:366
-#: lib/admin_web/components/layouts.ex:398
+#: lib/admin_web/components/layouts.ex:368
+#: lib/admin_web/components/layouts.ex:400
 #, elixir-autogen, elixir-format
 msgid "Get started"
 msgstr "Commencer"
 
-#: lib/admin_web/components/layouts.ex:344
-#: lib/admin_web/components/layouts.ex:380
+#: lib/admin_web/components/layouts.ex:346
+#: lib/admin_web/components/layouts.ex:382
 #, elixir-autogen, elixir-format
 msgid "Library"
 msgstr "Library"
 
-#: lib/admin_web/components/layouts.ex:370
-#: lib/admin_web/components/layouts.ex:402
+#: lib/admin_web/components/layouts.ex:372
+#: lib/admin_web/components/layouts.ex:404
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Se connecter"
 
-#: lib/admin_web/components/layouts.ex:353
-#: lib/admin_web/components/layouts.ex:385
+#: lib/admin_web/components/layouts.ex:355
+#: lib/admin_web/components/layouts.ex:387
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "À propos"
 
-#: lib/admin_web/components/layouts.ex:356
-#: lib/admin_web/components/layouts.ex:386
+#: lib/admin_web/components/layouts.ex:358
+#: lib/admin_web/components/layouts.ex:388
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Contact"
@@ -272,8 +272,8 @@ msgctxt "page_title"
 msgid "Documentation"
 msgstr "Documentation"
 
-#: lib/admin_web/components/layouts.ex:350
-#: lib/admin_web/components/layouts.ex:383
+#: lib/admin_web/components/layouts.ex:352
+#: lib/admin_web/components/layouts.ex:385
 #, elixir-autogen, elixir-format
 msgid "Support"
 msgstr "Soutien"
@@ -342,4 +342,10 @@ msgstr ""
 #: lib/admin_web/components/layouts.ex:195
 #, elixir-autogen, elixir-format
 msgid "Open navigation menu"
+msgstr ""
+
+#: lib/admin_web/live/trash_live/index.ex:42
+#, elixir-autogen, elixir-format
+msgctxt "page title"
+msgid "Trash Management"
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -59,44 +59,44 @@ msgstr "Per saperne di più"
 msgid "Recent Posts"
 msgstr "Articoli recenti"
 
-#: lib/admin_web/components/layouts.ex:359
-#: lib/admin_web/components/layouts.ex:389
+#: lib/admin_web/components/layouts.ex:361
+#: lib/admin_web/components/layouts.ex:391
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr "Amministratore"
 
-#: lib/admin_web/components/layouts.ex:347
-#: lib/admin_web/components/layouts.ex:381
+#: lib/admin_web/components/layouts.ex:349
+#: lib/admin_web/components/layouts.ex:383
 #, elixir-autogen, elixir-format
 msgid "Blog"
 msgstr "Blog"
 
-#: lib/admin_web/components/layouts.ex:366
-#: lib/admin_web/components/layouts.ex:398
+#: lib/admin_web/components/layouts.ex:368
+#: lib/admin_web/components/layouts.ex:400
 #, elixir-autogen, elixir-format
 msgid "Get started"
 msgstr "Iniziare"
 
-#: lib/admin_web/components/layouts.ex:344
-#: lib/admin_web/components/layouts.ex:380
+#: lib/admin_web/components/layouts.ex:346
+#: lib/admin_web/components/layouts.ex:382
 #, elixir-autogen, elixir-format
 msgid "Library"
 msgstr "Biblioteca"
 
-#: lib/admin_web/components/layouts.ex:370
-#: lib/admin_web/components/layouts.ex:402
+#: lib/admin_web/components/layouts.ex:372
+#: lib/admin_web/components/layouts.ex:404
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Login"
 
-#: lib/admin_web/components/layouts.ex:353
-#: lib/admin_web/components/layouts.ex:385
+#: lib/admin_web/components/layouts.ex:355
+#: lib/admin_web/components/layouts.ex:387
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Di"
 
-#: lib/admin_web/components/layouts.ex:356
-#: lib/admin_web/components/layouts.ex:386
+#: lib/admin_web/components/layouts.ex:358
+#: lib/admin_web/components/layouts.ex:388
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Contatto"
@@ -272,8 +272,8 @@ msgctxt "page_title"
 msgid "Documentation"
 msgstr "Documentazione"
 
-#: lib/admin_web/components/layouts.ex:350
-#: lib/admin_web/components/layouts.ex:383
+#: lib/admin_web/components/layouts.ex:352
+#: lib/admin_web/components/layouts.ex:385
 #, elixir-autogen, elixir-format
 msgid "Support"
 msgstr "Supporto"
@@ -342,4 +342,10 @@ msgstr ""
 #: lib/admin_web/components/layouts.ex:195
 #, elixir-autogen, elixir-format
 msgid "Open navigation menu"
+msgstr ""
+
+#: lib/admin_web/live/trash_live/index.ex:42
+#, elixir-autogen, elixir-format
+msgctxt "page title"
+msgid "Trash Management"
 msgstr ""


### PR DESCRIPTION
The issue was coming from a wrong call to the delete_thumbnails function that was expecting a single item_id but was passed a list. The list was silently converted to a joined string and this string would exceed the maximum allowed key length in S3.

When testing in local, the key length was not throwing an error.