### PR TITLE
fix: improve trash page with job tracking and cancel button

### DIFF
--- a/lib/admin/recycled_items/cleanup_worker.ex
+++ b/lib/admin/recycled_items/cleanup_worker.ex
@@ -2,9 +2,14 @@ defmodule Admin.TrashCleanupWorker do
   @moduledoc """
   This worker cleans up the trash by deleting items that have not been restored 3 months.
   """
-  use Oban.Worker, queue: :trash_schedule
+
+  @queue_name :trash_schedule
+
+  use Oban.Worker, queue: @queue_name
 
   require Logger
+
+  def queue_name, do: @queue_name
 
   def perform(_args) do
     # fetch the 20k oldest trash items

--- a/lib/admin_web/live/trash_live/index.ex
+++ b/lib/admin_web/live/trash_live/index.ex
@@ -16,13 +16,23 @@ defmodule AdminWeb.TrashLive.Index do
           Items in user trash for less than 3 months
         </StatisticsComponents.stat>
       </div>
-      <p class="text-sm text-muted">These statistics update every 20 seconds.</p>
+      <p class="text-sm text-neutral">These statistics update every 20 seconds.</p>
       <div class="mt-4">
-        <button phx-click="run_cleanup" class="btn btn-primary">Run Cleanup</button>
+        <button phx-click="run_cleanup" disabled={@processing != nil} class="btn btn-primary">
+          Run Cleanup
+        </button>
+        <%= if @processing do %>
+          <span class="ml-2">Processing with jobId: {@processing}</span>
+          <.button phx-click="cancel_cleanup" class="btn btn-ghost">Cancel</.button>
+        <% end %>
       </div>
       <div class="mt-4">
         <%= if @cleanup_result do %>
-          <p>{inspect(@cleanup_result)}</p>
+          Cleanup report:
+          <ul>
+            <li>{inspect(@cleanup_result.success)} removed</li>
+            <li>{inspect(@cleanup_result.skipped)} skipped</li>
+          </ul>
         <% end %>
       </div>
     </Layouts.admin>
@@ -44,6 +54,7 @@ defmodule AdminWeb.TrashLive.Index do
         :recycled_stats,
         Admin.RecycledItems.get_stats()
       )
+      |> assign(:processing, get_processing_state())
       |> assign(:cleanup_result, nil)
 
     {:ok, socket}
@@ -54,12 +65,27 @@ defmodule AdminWeb.TrashLive.Index do
     |> Admin.TrashCleanupWorker.new()
     |> Oban.insert()
 
+    socket =
+      socket
+      |> assign(:processing, get_processing_state())
+
+    {:noreply, socket}
+  end
+
+  def handle_event("cancel_cleanup", _params, socket) do
+    :ok = socket.assigns.processing |> Oban.cancel_job()
+
+    socket =
+      socket
+      |> assign(:processing, nil)
+
     {:noreply, socket}
   end
 
   def handle_info(:update_stats, socket) do
     socket =
       socket
+      |> assign(:processing, get_processing_state())
       |> assign(
         :recycled_stats,
         Admin.RecycledItems.get_stats()
@@ -74,5 +100,14 @@ defmodule AdminWeb.TrashLive.Index do
       |> assign(:cleanup_result, result)
 
     {:noreply, socket}
+  end
+
+  defp get_processing_state do
+    %{running: running} = Oban.check_queue(queue: Admin.TrashCleanupWorker.queue_name())
+
+    case running do
+      [job_id | _] -> job_id
+      _ -> nil
+    end
   end
 end

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -344,7 +344,7 @@ msgstr ""
 msgid "Open navigation menu"
 msgstr ""
 
-#: lib/admin_web/live/trash_live/index.ex:42
+#: lib/admin_web/live/trash_live/index.ex:52
 #, elixir-autogen, elixir-format
 msgctxt "page title"
 msgid "Trash Management"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -344,7 +344,7 @@ msgstr ""
 msgid "Open navigation menu"
 msgstr ""
 
-#: lib/admin_web/live/trash_live/index.ex:42
+#: lib/admin_web/live/trash_live/index.ex:52
 #, elixir-autogen, elixir-format
 msgctxt "page title"
 msgid "Trash Management"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -344,7 +344,7 @@ msgstr ""
 msgid "Open navigation menu"
 msgstr ""
 
-#: lib/admin_web/live/trash_live/index.ex:42
+#: lib/admin_web/live/trash_live/index.ex:52
 #, elixir-autogen, elixir-format
 msgctxt "page title"
 msgid "Trash Management"

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -344,7 +344,7 @@ msgstr ""
 msgid "Open navigation menu"
 msgstr ""
 
-#: lib/admin_web/live/trash_live/index.ex:42
+#: lib/admin_web/live/trash_live/index.ex:52
 #, elixir-autogen, elixir-format
 msgctxt "page title"
 msgid "Trash Management"

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -344,7 +344,7 @@ msgstr ""
 msgid "Open navigation menu"
 msgstr ""
 
-#: lib/admin_web/live/trash_live/index.ex:42
+#: lib/admin_web/live/trash_live/index.ex:52
 #, elixir-autogen, elixir-format
 msgctxt "page title"
 msgid "Trash Management"

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -344,7 +344,7 @@ msgstr ""
 msgid "Open navigation menu"
 msgstr ""
 
-#: lib/admin_web/live/trash_live/index.ex:42
+#: lib/admin_web/live/trash_live/index.ex:52
 #, elixir-autogen, elixir-format
 msgctxt "page title"
 msgid "Trash Management"


### PR DESCRIPTION
In this PR I improve the trash monitoring page.

The page now shows:
- if there is a job executing currently
- a cancel button to cancel a currently running job

