### PR TITLE
fix: remove nil values from s3 config

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ admin:
     AWS_S3_HOST: s3.garage.localhost
     # The port that the s3 api responds to for garage
     AWS_S3_PORT: 3900
+    # Use path style (default for aws s3 is to put bucket_name as sub-domain)
+    AWS_S3_USE_PATH_STYLE: true
     # Override the Mailer adapter from AWS SES to use a simple SMTP server (either a local mailcatcher or external SMTP server)
     MAILER_CONNECTION: smtp://docker:docker@mailer:1025
   ports:

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -187,7 +187,7 @@ if config_env() == :prod do
   s3_config =
     [
       # If using custom endpoints like LocalStack or MinIO, path_style: true is often necessary.
-      path_style: true,
+      path_style: System.get_env("AWS_S3_USE_PATH_STYLE") == "true",
       region: System.get_env("AWS_REGION", "eu-central-1"),
       scheme: System.get_env("AWS_S3_SCHEME"),
       host: System.get_env("AWS_S3_HOST"),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -178,19 +178,25 @@ if config_env() == :prod do
   config :admin, :file_items_bucket, System.get_env("FILE_ITEMS_BUCKET_NAME", "file-items")
   config :admin, :h5p_bucket, System.get_env("H5P_CONTENT_BUCKET_NAME", "h5p-items")
 
-  config :ex_aws, :s3,
-    region: System.get_env("AWS_REGION", "eu-central-1"),
-    scheme: System.get_env("AWS_S3_SCHEME", "https"),
-    host: System.get_env("AWS_S3_HOST"),
-    port: System.get_env("AWS_S3_PORT", nil),
-    # If using custom endpoints like LocalStack or MinIO, path_style: true is often necessary.
-    path_style: true
-
   # Configure Ex_AWS using first env vars, then instance role (automatic credentials in ECS tasks)
   config :ex_aws,
     access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, :instance_role, :pod_identity],
     secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, :instance_role, :pod_identity],
     region: {:system, "AWS_REGION"}
+
+  s3_config =
+    [
+      # If using custom endpoints like LocalStack or MinIO, path_style: true is often necessary.
+      path_style: true,
+      region: System.get_env("AWS_REGION", "eu-central-1"),
+      scheme: System.get_env("AWS_S3_SCHEME", "https"),
+      host: System.get_env("AWS_S3_HOST"),
+      port: System.get_env("AWS_S3_PORT", nil)
+    ]
+    # remove nil values
+    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+
+  config :ex_aws, :s3, s3_config
 
   # override the ses region to use Frankfurt since SES does not exist in eu-central-2
   config :ex_aws, :ses, region: "eu-central-1"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -189,9 +189,9 @@ if config_env() == :prod do
       # If using custom endpoints like LocalStack or MinIO, path_style: true is often necessary.
       path_style: true,
       region: System.get_env("AWS_REGION", "eu-central-1"),
-      scheme: System.get_env("AWS_S3_SCHEME", "https"),
+      scheme: System.get_env("AWS_S3_SCHEME"),
       host: System.get_env("AWS_S3_HOST"),
-      port: System.get_env("AWS_S3_PORT", nil)
+      port: System.get_env("AWS_S3_PORT")
     ]
     # remove nil values
     |> Enum.reject(fn {_k, v} -> is_nil(v) end)

--- a/lib/admin/s3.ex
+++ b/lib/admin/s3.ex
@@ -88,16 +88,16 @@ defmodule Admin.S3 do
   end
 
   def delete_with_prefix(bucket, prefix) when is_binary(prefix) do
-    stream =
+    :ok =
       S3.list_objects(bucket, prefix: prefix)
       |> @ex_aws_mod.stream!()
       |> Stream.map(& &1.key)
-
-    {:ok, _} =
-      S3.delete_all_objects(bucket, stream)
-      |> @ex_aws_mod.request()
-
-    :ok
+      # chunk stream so we never get empty batches
+      |> Stream.chunk_every(1000)
+      |> Stream.each(fn batch ->
+        {:ok, _} = S3.delete_all_objects(bucket, batch) |> @ex_aws_mod.request()
+      end)
+      |> Stream.run()
   end
 
   def list_folders(bucket, prefix) do

--- a/test/admin/h5p_items_test.exs
+++ b/test/admin/h5p_items_test.exs
@@ -20,7 +20,18 @@ defmodule Admin.H5PItemsTest do
         assert operation.params == %{"prefix" => "h5p-content/#{content_id}"}
 
         # return an empty list of buckets
-        Stream.resource(fn -> :ok end, fn _ -> {:halt, :ok} end, fn _ -> [] end)
+        Stream.resource(
+          fn -> 0 end,
+          fn acc ->
+            case acc do
+              3 -> {:halt, acc}
+              _ -> {[%{key: "some_key_#{acc}"}], acc + 1}
+            end
+          end,
+          fn _ ->
+            :ok
+          end
+        )
       end)
 
       expect(ExAwsMock, :request, fn operation ->


### PR DESCRIPTION
In this PR, I address some issues that were introduced when allowing to override s3 configuration for local options. When the env vars are not set, we should not pass nil to the options as this will override the default values used by ex_aws. To fis this we filter the keyword list of options to remove keys that have nil values.