### PR TITLE
fix: add indexes to improve perf when creating meilisearch data

### DIFF
--- a/priv/repo/migrations/20260430121745_improve_indexing_library.exs
+++ b/priv/repo/migrations/20260430121745_improve_indexing_library.exs
@@ -1,0 +1,26 @@
+defmodule Admin.Repo.Migrations.ImproveIndexingLibrary do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    execute(
+      """
+      CREATE INDEX CONCURRENTLY idx_item_creator_not_deleted_path
+      ON item (creator_id, path)
+      WHERE deleted_at IS NULL;
+      """,
+      "DROP INDEX CONCURRENTLY idx_item_creator_not_deleted_path;"
+    )
+
+    execute(
+      """
+      CREATE INDEX CONCURRENTLY idx_item_path_not_deleted
+      ON item (path)
+      WHERE deleted_at IS NULL;
+      """,
+      "DROP INDEX CONCURRENTLY idx_item_path_not_deleted;"
+    )
+  end
+end


### PR DESCRIPTION
For some context:

```sql
-- query that fetches published items to be indexed (was very slow in prod)

select "published_items"."id", "published_items"."created_at", "published_items"."creator_id", "published_items"."item_path", "published_items"."updated_at", "item_view"."id", "item_view"."name", "item_view"."type", "item_view"."description", "item_view"."path", "item_view"."creator_id", "item_view"."extra", "item_view"."settings", "item_view"."created_at", "item_view"."updated_at", "item_view"."lang", "item_view"."order", "members_view"."id", "members_view"."name", "members_view"."email", "members_view"."extra", "members_view"."type", "members_view"."created_at", "members_view"."updated_at", "members_view"."user_agreements_date", "members_view"."enable_save_actions", "members_view"."last_authenticated_at", "members_view"."is_validated", "members_view"."marketing_emails_subscribed_at" from "published_items" inner join "item_view" on "published_items"."item_path" = "item_view"."path" inner join "members_view" on "item_view"."creator_id" = "members_view"."id" limit $1 offset $2
```

```sql
-- create an index that has the user_id and deleted_at and path
CREATE INDEX CONCURRENTLY idx_item_creator_not_deleted_path
ON item (creator_id, path)
WHERE deleted_at IS NULL;

CREATE INDEX CONCURRENTLY idx_item_path_not_deleted
ON item (path)
WHERE deleted_at IS NULL;

-- 4 minutes instead of 1h+ ... because the query was taking 20s to get 10 published items ...
```